### PR TITLE
Fix sitemap recursion loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # Fresh Cache PHP
 
 A PHP script that periodically refreshes cache files by crawling the specified website.
+
+## Features
+
+- Parses sitemap files recursively.
+- Skips sitemaps that have already been processed to avoid infinite loops caused by cyclic references.

--- a/SitemapParser.php
+++ b/SitemapParser.php
@@ -4,6 +4,7 @@ class SitemapParser {
     private $urls = [];
     private $sitemaps = [];
     private $failedSitemaps = [];
+    private $visitedSitemaps = [];
     private $crawlDelay;
     private $logFile;
 
@@ -14,6 +15,11 @@ class SitemapParser {
 
     // Fetch the sitemap and extract URLs
     public function fetchSitemap($sitemapUrl) {
+        if (isset($this->visitedSitemaps[$sitemapUrl])) {
+            return;
+        }
+        $this->visitedSitemaps[$sitemapUrl] = true;
+
         $sitemapContent = @file_get_contents($sitemapUrl); // suppress warnings
         if ($sitemapContent === false) {
             echo "Failed to fetch the sitemap: $sitemapUrl\n";


### PR DESCRIPTION
## Summary
- avoid infinite loops by tracking visited sitemaps
- document new behaviour

## Testing
- `php -l SitemapParser.php cache_refresh.php`
- `php cache_refresh.php --count` with a circular sitemap setup

------
https://chatgpt.com/codex/tasks/task_e_684fd13b2cfc8328a3fdb99f89c2adf9